### PR TITLE
feat: randomize initial experiment selection and update webcam label

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import AsciiMetaBalls from './experiments/AsciiMetaBalls';
 
 const EXPERIMENTS = {
   RIPPLE: 'waves',
-  WEBCAM: 'ascii camera',
+  WEBCAM: 'ascii cam',
   LIQUID: 'liquid',
 } as const;
 
@@ -18,6 +18,14 @@ const EXPERIMENT_COMPONENTS: Record<Experiment, React.ComponentType> = {
   [EXPERIMENTS.RIPPLE]: AsciiRipple,
   [EXPERIMENTS.WEBCAM]: AsciiWebcam,
   [EXPERIMENTS.LIQUID]: AsciiMetaBalls,
+};
+
+// Function to randomly select either waves or ripple
+const getRandomInitialExperiment = (): Experiment => {
+  // We only want to randomly choose between RIPPLE (waves) and LIQUID (liquid)
+  const options = [EXPERIMENTS.RIPPLE, EXPERIMENTS.LIQUID];
+  const randomIndex = Math.floor(Math.random() * options.length);
+  return options[randomIndex];
 };
 
 const ExperimentChooser = ({
@@ -68,7 +76,10 @@ const StyleInitializer = ({ children }: { children: React.ReactNode }) => {
 };
 
 const App = () => {
-  const [experiment, setExperiment] = useState<Experiment>(EXPERIMENTS.RIPPLE);
+  // Initialize with a random experiment between waves and ripple
+  const [experiment, setExperiment] = useState<Experiment>(
+    getRandomInitialExperiment()
+  );
 
   const ExperimentComponent = EXPERIMENT_COMPONENTS[experiment];
 
@@ -82,6 +93,7 @@ const App = () => {
     </>
   );
 };
+
 const rootElement = document.getElementById('root');
 if (!rootElement) throw new Error('Failed to find the root element');
 


### PR DESCRIPTION
This pull request to `src/main.tsx` includes changes to improve the initialization and selection of experiments in the application. The most important changes include modifying the `WEBCAM` experiment name, adding a function to randomly select an initial experiment, and updating the initial experiment state to use this new function.

Improvements to experiment initialization and selection:

* Modified the `WEBCAM` experiment name from 'ascii camera' to 'ascii cam'.
* Added a new function `getRandomInitialExperiment` to randomly select between the `RIPPLE` (waves) and `LIQUID` (liquid) experiments.
* Updated the initial state of the experiment in the `App` component to use the `getRandomInitialExperiment` function for a random initial experiment.
* Added a new line at the end of the `App` component for better code formatting.